### PR TITLE
fix: replace simple pattern with parse_json_request function in final_task

### DIFF
--- a/packages/python/src/mainframe_orchestra/task.py
+++ b/packages/python/src/mainframe_orchestra/task.py
@@ -1106,13 +1106,8 @@ The original task instruction:
 
             if self.require_json_output and not isinstance(result, (AsyncIterator, Iterator)):
                 try:
-                    if isinstance(result, str):
-                        json_match = re.search(r"\{.*?\}", result, re.DOTALL)
-                        if json_match:
-                            return json.loads(json_match.group(0))
-                    return json.loads(result)
-
-                except json.JSONDecodeError as e:
+                    return parse_json_response(result)
+                except ValueError as e:
                     return ValueError(f"Failed to parse JSON from LLM response: {result}\nError: {e}")
 
 


### PR DESCRIPTION
replace the simplified pattern for parsing json response in final_task when require_json is true with the parse_json_response function's more robust pattern