### PR TITLE
Add configurable on/off switch for Braintrust integration

### DIFF
--- a/docs/src/observability.md
+++ b/docs/src/observability.md
@@ -12,16 +12,23 @@ To enable Braintrust integration:
    ```
    export BRAINTRUST_API_KEY=your_api_key
    ```
-3. Ensure the `BRAINTRUST_ORCHESTRA_DISABLED` environment variable is not set, or is set to False
+3. By default, Braintrust is automatically enabled when the API key is present
+
+To explicitly enable Braintrust integration:
+```
+export BRAINTRUST_ORCHESTRA_ENABLED=true
+```
 
 To disable Braintrust integration inside Orchestra:
 ```
-export BRAINTRUST_ORCHESTRA_DISABLED=true
+export BRAINTRUST_ORCHESTRA_ENABLED=false
 ```
 
-You can also use `1` or `yes` as values to disable it. Braintrust integration is automatically enabled when:
+You can also use `0` or `no` as values to disable it, or `1` or `yes` to enable it. Braintrust integration is automatically enabled when:
 1. The `braintrust` package is installed
 2. The `BRAINTRUST_API_KEY` environment variable is set with a valid API key
-3. The `BRAINTRUST_ORCHESTRA_DISABLED` environment variable is not set to disable it
+3. The `BRAINTRUST_ORCHESTRA_ENABLED` environment variable is either:
+   - Set to enable it (`true`, `1`, or `yes`)
+   - Not set at all (defaults to enabled when API key exists)
 
 When enabled, Braintrust will trace all tool calls and requests to OpenAI, OpenRouter, Groq, Together AI, and Deepseek, providing detailed logs and analytics in your Braintrust dashboard.

--- a/packages/python/src/mainframe_orchestra/utils/braintrust_utils.py
+++ b/packages/python/src/mainframe_orchestra/utils/braintrust_utils.py
@@ -7,8 +7,12 @@ This module provides fallback decorators when Braintrust is not available.
 
 import os
 
-# Check if Braintrust integration is explicitly disabled via environment variable.
-BRAINTRUST_DISABLED = os.environ.get("BRAINTRUST_ORCHESTRA_DISABLED", "").lower() in ("true", "1", "yes")
+# Check if Braintrust integration is explicitly enabled or disabled via environment variable.
+# Default to enabled if API key is present and no explicit setting
+BRAINTRUST_API_KEY_EXISTS = os.environ.get("BRAINTRUST_API_KEY", "") != ""
+BRAINTRUST_ENABLED = os.environ.get("BRAINTRUST_ORCHESTRA_ENABLED", "").lower() in ("true", "1", "yes") or (
+    BRAINTRUST_API_KEY_EXISTS and os.environ.get("BRAINTRUST_ORCHESTRA_ENABLED", None) is None
+)
 
 # Default implementation of no-op decorators
 def traced(func=None, **kwargs):
@@ -23,8 +27,8 @@ def wrap_openai(func):
     """No-op decorator when Braintrust is not available"""
     return func
 
-# Try to import Braintrust if not disabled
-if not BRAINTRUST_DISABLED:
+# Try to import Braintrust if enabled
+if BRAINTRUST_ENABLED:
     try:
         from braintrust import traced, wrap_openai
     except ImportError:


### PR DESCRIPTION
## Summary
- Replace negative logic (BRAINTRUST_ORCHESTRA_DISABLED) with positive logic (BRAINTRUST_ORCHESTRA_ENABLED)
- Make Braintrust integration auto-enabled by default when API key exists
- Update documentation to reflect the new behavior
- Provide explicit environment variable (BRAINTRUST_ORCHESTRA_ENABLED) for easier configuration

## Test plan
- Verify that Braintrust automatically enables when API key is present
- Verify that setting BRAINTRUST_ORCHESTRA_ENABLED=false disables Braintrust integration
- Verify that explicit BRAINTRUST_ORCHESTRA_ENABLED=true enables integration
- Verify that documentation is clear and accurate

🤖 Generated with Claude Code