### PR TITLE
chore: add observability and mcp-integration files to scalar config

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -36,6 +36,14 @@
           "type": "page"
         },
         {
+          "path": "docs/src/observability.md",
+          "type": "page"
+        },
+        {
+          "path": "docs/src/mcp-integration.md",
+          "type": "page"
+        },
+        {
           "name": "Tools",
           "type": "folder",
           "children": [


### PR DESCRIPTION
Adds mcp-integration and observability pages to scalar.config.json to add to the orchestra docs site