### PR TITLE
chore: update mcp-integration url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ By combining agents, tasks, tools, and language models, you can create a wide ra
   - List available tools from an MCP server
   - Convert external tools into Orchestra-compatible callables for agents to use
 
-For documentation on MCP integration, visit our [MCP Integration Guide](https://docs.orchestra.org/orchestra/mcp-integration).
+For documentation on MCP integration, visit our [MCP Integration Guide](https://docs.orchestra.org/orchestra/mcp-integration-with-orchestra).
 
 
 ## Streaming Support

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -286,7 +286,7 @@ By combining agents, tasks, tools, and language models, you can create a wide ra
   - List available tools from an MCP server
   - Convert external tools into Orchestra-compatible callables for agents to use
 
-For documentation on MCP integration, visit our [MCP Integration Guide](https://docs.orchestra.org/orchestra/mcp-integration).
+For documentation on MCP integration, visit our [MCP Integration Guide](https://docs.orchestra.org/orchestra/mcp-integration-with-orchestra).
 
 
 ## Streaming Support


### PR DESCRIPTION
Updates the MCP-integrations URL in the readme files to match the scalar docs url