### PR TITLE
chore: patch image data to only send when available

### DIFF
--- a/packages/python/src/mainframe_orchestra/task.py
+++ b/packages/python/src/mainframe_orchestra/task.py
@@ -449,10 +449,13 @@ class Task(BaseModel):
         llm_params = {
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
-            "image_data": self.image_data,
             "require_json_output": self.require_json_output,
             "stream": self.stream,
         }
+
+        # Only add image_data if it exists
+        if self.image_data:
+            llm_params["image_data"] = self.image_data
 
         # Convert single LLM to list for unified handling
         llms = [self.llm] if callable(self.llm) else list(self.llm)


### PR DESCRIPTION
Patch to avoid sending image_data when not provided, now it only adds the param if image data is actually provided