### PR TITLE
Feat/add close method mcp adapter

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mainframe-orchestra"
-version = "0.0.33"
+version = "0.0.34"
 description = "Mainframe-Orchestra is a lightweight, open-source agentic framework for building LLM based pipelines and self-orchestrating multi-agent teams"
 authors = [
     "Mainframe Computer Inc. <hi@mainfra.me>",

--- a/packages/python/src/mainframe_orchestra/__init__.py
+++ b/packages/python/src/mainframe_orchestra/__init__.py
@@ -3,7 +3,7 @@ Mainframe Orchestra: a Python framework for building and orchestrating multi-age
 """
 # Copyright 2024 Mainframe-Orchestra Contributors. Licensed under Apache License 2.0.
 
-__version__ = "0.0.33"
+__version__ = "0.0.34"
 
 import importlib
 

--- a/packages/python/src/mainframe_orchestra/task.py
+++ b/packages/python/src/mainframe_orchestra/task.py
@@ -706,10 +706,10 @@ The original task instruction:
                         if "tool" not in tool_call:
                             raise ValueError("Each tool call must specify a 'tool' name")
 
+                        # Make params default to empty dict if not provided
                         if "params" not in tool_call:
-                            raise ValueError("Each tool call must include 'params'")
-
-                        if not isinstance(tool_call["params"], dict):
+                            tool_call["params"] = {}
+                        elif not isinstance(tool_call["params"], dict):
                             raise ValueError("Tool 'params' must be an object")
 
                         tool_name = tool_call.get("tool")


### PR DESCRIPTION
Accepts tool calls formatted without the 'params' field as being a blank params field to permit it as a function call without arguments, which helps with compatibility with different types of tools and adapters.

Also adds a close method to the MCP adapter to close connections where they're started for better connection management